### PR TITLE
Feature/doughnut fix

### DIFF
--- a/dist/Doughnut.d.ts
+++ b/dist/Doughnut.d.ts
@@ -6,5 +6,4 @@ import Raw from '@polkadot/types/codec/Raw';
 export default class Doughnut extends Raw implements Codec {
     get encodedLength(): number;
     constructor(registry: Registry, value?: AnyU8a);
-    toU8a(isBare?: boolean): Uint8Array;
 }

--- a/dist/Doughnut.js
+++ b/dist/Doughnut.js
@@ -14,7 +14,6 @@
 // limitations under the License.
 Object.defineProperty(exports, "__esModule", { value: true });
 const Bytes_1 = require("@polkadot/types/primitive/Bytes");
-const Compact_1 = require("@polkadot/types/codec/Compact");
 const Raw_1 = require("@polkadot/types/codec/Raw");
 /**
  * An encoded, signed v0 Doughnut certificate
@@ -34,10 +33,6 @@ class Doughnut extends Raw_1.default {
         else {
             super(registry, value);
         }
-    }
-    toU8a(isBare) {
-        // Encode the doughnut with length prefix to support SCALE codec
-        return isBare ? this : Compact_1.default.addLengthPrefix(this);
     }
 }
 exports.default = Doughnut;

--- a/dist/ExtrinsicSignature.js
+++ b/dist/ExtrinsicSignature.js
@@ -108,7 +108,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
     createPayload(method, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }) {
         return new ExtrinsicPayload_1.default(this.registry, {
             blockHash,
-            doughnut: doughnut,
+            doughnut,
             era: era || constants_1.IMMORTAL_ERA,
             genesisHash,
             method: method.toHex(),

--- a/dist/ExtrinsicSignature.js
+++ b/dist/ExtrinsicSignature.js
@@ -100,7 +100,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Adds a raw signature
      */
     addSignature(signer, signature, payload) {
-        return this.injectSignature(create_1.createType(this.registry, 'Address', signer, 0), create_1.createType(this.registry, 'MultiSignature', signature), new ExtrinsicPayload_1.default(this.registry, payload));
+        return this.injectSignature(create_1.createType(this.registry, 'Address', signer), create_1.createType(this.registry, 'MultiSignature', signature), new ExtrinsicPayload_1.default(this.registry, payload));
     }
     /**
      * @description Creates a payload from the supplied options
@@ -108,7 +108,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
     createPayload(method, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }) {
         return new ExtrinsicPayload_1.default(this.registry, {
             blockHash,
-            doughnut: doughnut /*|| createType(this.registry, 'Option<Doughnut>')*/,
+            doughnut: doughnut,
             era: era || constants_1.IMMORTAL_ERA,
             genesisHash,
             method: method.toHex(),
@@ -121,7 +121,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Generate a payload and applies the signature from a keypair
      */
     sign(method, account, options) {
-        const signer = create_1.createType(this.registry, 'Address', account.publicKey, 0);
+        const signer = create_1.createType(this.registry, 'Address', account.publicKey);
         const payload = this.createPayload(method, options);
         const signature = create_1.createType(this.registry, 'MultiSignature', payload.sign(account));
         return this.injectSignature(signer, signature, payload);
@@ -130,7 +130,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Generate a payload and applies a fake signature
      */
     signFake(method, address, options) {
-        const signer = create_1.createType(this.registry, 'Address', address, 0);
+        const signer = create_1.createType(this.registry, 'Address', address);
         const payload = this.createPayload(method, options);
         const signature = create_1.createType(this.registry, 'MultiSignature', util_1.u8aConcat(new Uint8Array([1]), new Uint8Array(64).fill(0x42)));
         return this.injectSignature(signer, signature, payload);

--- a/dist/ExtrinsicSignature.js
+++ b/dist/ExtrinsicSignature.js
@@ -100,7 +100,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Adds a raw signature
      */
     addSignature(signer, signature, payload) {
-        return this.injectSignature(create_1.createType(this.registry, 'Address', signer), create_1.createType(this.registry, 'MultiSignature', signature), new ExtrinsicPayload_1.default(this.registry, payload));
+        return this.injectSignature(create_1.createType(this.registry, 'Address', signer, 0), create_1.createType(this.registry, 'MultiSignature', signature), new ExtrinsicPayload_1.default(this.registry, payload));
     }
     /**
      * @description Creates a payload from the supplied options
@@ -108,7 +108,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
     createPayload(method, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }) {
         return new ExtrinsicPayload_1.default(this.registry, {
             blockHash,
-            doughnut: doughnut || create_1.createType(this.registry, 'Option<Doughnut>'),
+            doughnut: doughnut /*|| createType(this.registry, 'Option<Doughnut>')*/,
             era: era || constants_1.IMMORTAL_ERA,
             genesisHash,
             method: method.toHex(),
@@ -121,7 +121,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Generate a payload and applies the signature from a keypair
      */
     sign(method, account, options) {
-        const signer = create_1.createType(this.registry, 'Address', account.publicKey);
+        const signer = create_1.createType(this.registry, 'Address', account.publicKey, 0);
         const payload = this.createPayload(method, options);
         const signature = create_1.createType(this.registry, 'MultiSignature', payload.sign(account));
         return this.injectSignature(signer, signature, payload);
@@ -130,7 +130,7 @@ class PlugExtrinsicSignatureV1 extends Struct_1.default {
      * @description Generate a payload and applies a fake signature
      */
     signFake(method, address, options) {
-        const signer = create_1.createType(this.registry, 'Address', address);
+        const signer = create_1.createType(this.registry, 'Address', address, 0);
         const payload = this.createPayload(method, options);
         const signature = create_1.createType(this.registry, 'MultiSignature', util_1.u8aConcat(new Uint8Array([1]), new Uint8Array(64).fill(0x42)));
         return this.injectSignature(signer, signature, payload);

--- a/types/Doughnut.ts
+++ b/types/Doughnut.ts
@@ -37,13 +37,4 @@ export default class Doughnut extends Raw implements Codec {
             super(registry, value);
         }
     }
-
-// Removed unneeded length encoding behaviour in favour of inherited behavour.
-// Note that this change may be relying on the doughnut being wrapped in an Option<> which
-// will encode the length of it's payload (a doughnut in this case)
-//
-//   toU8a(isBare?: boolean): Uint8Array {
-//     // Encode the doughnut with length prefix to support SCALE codec
-//     return isBare ? (this as Uint8Array) : Compact.addLengthPrefix(this);
-//   }
 }

--- a/types/Doughnut.ts
+++ b/types/Doughnut.ts
@@ -38,8 +38,12 @@ export default class Doughnut extends Raw implements Codec {
         }
     }
 
-  toU8a(isBare?: boolean): Uint8Array {
-    // Encode the doughnut with length prefix to support SCALE codec
-    return isBare ? (this as Uint8Array) : Compact.addLengthPrefix(this);
-  }
+// Removed unneeded length encoding behaviour in favour of inherited behavour.
+// Note that this change may be relying on the doughnut being wrapped in an Option<> which
+// will encode the length of it's payload (a doughnut in this case)
+//
+//   toU8a(isBare?: boolean): Uint8Array {
+//     // Encode the doughnut with length prefix to support SCALE codec
+//     return isBare ? (this as Uint8Array) : Compact.addLengthPrefix(this);
+//   }
 }

--- a/types/ExtrinsicSignature.ts
+++ b/types/ExtrinsicSignature.ts
@@ -162,7 +162,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
   public createPayload (method: Call, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }: SignatureOptions): PlugExtrinsicPayloadV1 {
     return new PlugExtrinsicPayloadV1(this.registry, {
       blockHash,
-      doughnut: doughnut,
+      doughnut,
       era: era || IMMORTAL_ERA,
       genesisHash,
       method: method.toHex(),

--- a/types/ExtrinsicSignature.ts
+++ b/types/ExtrinsicSignature.ts
@@ -150,7 +150,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    */
   public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: PlugExtrinsicPayloadValue | Uint8Array | string): IExtrinsicSignature {
     return this.injectSignature(
-      createType(this.registry, 'Address', signer),
+      createType(this.registry, 'Address', signer, 0),
       createType(this.registry, 'MultiSignature', signature),
       new PlugExtrinsicPayloadV1(this.registry, payload)
     );
@@ -162,7 +162,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
   public createPayload (method: Call, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }: SignatureOptions): PlugExtrinsicPayloadV1 {
     return new PlugExtrinsicPayloadV1(this.registry, {
       blockHash,
-      doughnut: doughnut || createType(this.registry, 'Option<Doughnut>'),
+      doughnut: doughnut /*|| createType(this.registry, 'Option<Doughnut>')*/, // Removed to prevent empty uninitialised doughnuts from being submitted when none required
       era: era || IMMORTAL_ERA,
       genesisHash,
       method: method.toHex(),
@@ -176,7 +176,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = createType(this.registry, 'Address', account.publicKey);
+    const signer = createType(this.registry, 'Address', account.publicKey, 0);
     const payload = this.createPayload(method, options);
     const signature = createType(this.registry, 'MultiSignature', payload.sign(account));
 
@@ -187,7 +187,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    * @description Generate a payload and applies a fake signature
    */
   public signFake (method: Call, address: Address | Uint8Array | string, options: SignatureOptions): IExtrinsicSignature {
-    const signer = createType(this.registry, 'Address', address);
+    const signer = createType(this.registry, 'Address', address, 0);
     const payload = this.createPayload(method, options);
     const signature = createType(this.registry, 'MultiSignature', u8aConcat(new Uint8Array([1]), new Uint8Array(64).fill(0x42)));
 

--- a/types/ExtrinsicSignature.ts
+++ b/types/ExtrinsicSignature.ts
@@ -150,7 +150,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    */
   public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: PlugExtrinsicPayloadValue | Uint8Array | string): IExtrinsicSignature {
     return this.injectSignature(
-      createType(this.registry, 'Address', signer, 0),
+      createType(this.registry, 'Address', signer),
       createType(this.registry, 'MultiSignature', signature),
       new PlugExtrinsicPayloadV1(this.registry, payload)
     );
@@ -162,7 +162,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
   public createPayload (method: Call, { blockHash, doughnut, era, genesisHash, nonce, runtimeVersion: { specVersion }, tip }: SignatureOptions): PlugExtrinsicPayloadV1 {
     return new PlugExtrinsicPayloadV1(this.registry, {
       blockHash,
-      doughnut: doughnut /*|| createType(this.registry, 'Option<Doughnut>')*/, // Removed to prevent empty uninitialised doughnuts from being submitted when none required
+      doughnut: doughnut,
       era: era || IMMORTAL_ERA,
       genesisHash,
       method: method.toHex(),
@@ -176,7 +176,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = createType(this.registry, 'Address', account.publicKey, 0);
+    const signer = createType(this.registry, 'Address', account.publicKey);
     const payload = this.createPayload(method, options);
     const signature = createType(this.registry, 'MultiSignature', payload.sign(account));
 
@@ -187,7 +187,7 @@ export default class PlugExtrinsicSignatureV1 extends Struct implements IExtrins
    * @description Generate a payload and applies a fake signature
    */
   public signFake (method: Call, address: Address | Uint8Array | string, options: SignatureOptions): IExtrinsicSignature {
-    const signer = createType(this.registry, 'Address', address, 0);
+    const signer = createType(this.registry, 'Address', address);
     const payload = this.createPayload(method, options);
     const signature = createType(this.registry, 'MultiSignature', u8aConcat(new Uint8Array([1]), new Uint8Array(64).fill(0x42)));
 


### PR DESCRIPTION
Made changes that fixed issues with passing doughnuts:

1. The Doughnut class overloaded the toU8a() method, adding in a length encoding that the plug code was not expecting and resulting in decoding errors. Removing the overloaded method allows encoding to default to the raw implementation, fixing the issue.  This change apparently matches similar changes made by @KarishmaBothara in CENNZNet code.

2. When building the extrinsic signature, an uninitialised doughnut was being created, regardless of whether one was being passed by the caller. Removal of the code that created a default doughnut in ExtrinsicSignature.ts/createPayload() if none was passed fixed the issue.
